### PR TITLE
Payload links instead of signingManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - documented how to test signingscript in `README.rst`.
 
+### Changed
+
+- switched from `task.payload.signingManifest` to `task.payload.unsignedArtifacts`.
+
 ## [0.3.0] - 2016-08-12
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -138,29 +138,11 @@ Scriptworker will expect to find a config.json for the scriptworker
 config, so I name the signingscript config json ``script_config.json``.
 You can name it whatever you'd like.
 
-signing manifest json
-~~~~~~~~~~~~~~~~~~~~~
+file to sign
+~~~~~~~~~~~~
 
-The signing manifest may or may not stick around (see `bug 1277579
-comment
-16 <https://bugzilla.mozilla.org/show_bug.cgi?id=1277579#c16>`__). Until
-we change things, this is the format:
-
-::
-
-    [{
-      // the filename of the file to sign.
-      "file_to_sign": "test.mar",
-
-      // the sha512 of the file to sign.  generate this via `openssl sha512 FILE`
-      "sha": "d6d523d65bbcd2ba72f3eacfc2ba57bf87fa64804fb48cee61e0c56a26146f7499baf42332b490698108b71d7984845bea9e2ca2e1336e6fbe4707449df0901d"
-    }]
-
-Multiple files may be listed, each in their own dictionary in the list.
-
-Put the signing manifest json + the file(s) to sign somewhere where they
-can be reached via the web; you'll point to the signing manifest's URL
-in the task.json below.
+Put the file(s) to sign somewhere where they can be reached via the web;
+you'll point to their URL(s) in the task.json below.
 
 task.json
 ~~~~~~~~~
@@ -191,7 +173,9 @@ It will look like this:
         "source": "https://tools.taskcluster.net/task-creator/"
       },
       "payload": {
-        "signingManifest": "http://people.mozilla.org/~asasaki/signing/signingManifest.json",
+        "unsignedArtifacts": [
+          "http://people.mozilla.org/~asasaki/signing/test.mar"
+        ],
         "maxRunTime": 600
       },
       "priority": "normal",
@@ -209,9 +193,9 @@ It will look like this:
       "workerType": "dummy-worker-aki"
     }
 
-The important entries to edit are the ``signingManifest`` (point this at
-the signing manifest you created above), and the scopes. The first
-scope, ``project:releng:signing:cert:dep-signing``, matches the scope in
+The important entries to edit are the ``unsignedArtifacts`` (point this
+at URLs of the file(s) to sign), and the scopes. The first scope,
+``project:releng:signing:cert:dep-signing``, matches the scope in
 your password json that you created. The second scope,
 ``project:releng:signing:format:gpg``, specifies which signing format to
 use. (You can specify multiple formats by adding multiple
@@ -230,11 +214,11 @@ You're ready to run signingscript!
 
 where ``CONFIG_FILE`` is the config json you created above.
 
-This should download the ``signingManifest``, download the file(s)
-specified in the manifest, download a token from the
-docker-signing-server, upload the file(s) to the docker-signing-server
-to sign, download the signed bits from the docker-signing-server, and
-then copy the signed bits into the ``artifact_dir``.
+This should download the file(s) specified in the payload, download a
+token from the docker-signing-server, upload the file(s) to the
+docker-signing-server to sign, download the signed bits from the
+docker-signing-server, and then copy the signed bits into the
+``artifact_dir``.
 
 troubleshooting
 ~~~~~~~~~~~~~~~

--- a/signingscript/data/signing_task_schema.json
+++ b/signingscript/data/signing_task_schema.json
@@ -1,5 +1,5 @@
 {
-    "title": "Taskcluster MAR signing task minimal schema",
+    "title": "Taskcluster signing task minimal schema",
     "type": "object",
     "properties": {
         "scopes": {
@@ -11,29 +11,19 @@
             }
         },
         "payload": {
-            "type": "object",
-            "properties": {
-                "signingManifest": {
-                    "type": "string"
-                }
-            },
-            "required": ["signingManifest"]
-        },
-        "extra": {
-            "type": "object",
-            "properties": {
-                "signing": {
-                    "type": "object",
-                    "properties": {
-                        "signature": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["signature"]
-                }
-            },
-            "required": ["signing"]
+          "type": "object",
+          "properties": {
+            "unsignedArtifacts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": ["unsignedArtifacts"]
         }
     },
-    "required": ["scopes", "payload", "extra"]
+    "required": ["scopes", "payload"]
 }

--- a/signingscript/script.py
+++ b/signingscript/script.py
@@ -53,7 +53,6 @@ async def async_main(context):
         copy_to_artifact_dir(context, source)
         for detached_tuple in detached_signatures:
             copy_to_artifact_dir(context, detached_tuple[1])
-    # TODO manifest
     log.info("Done!")
 
 
@@ -104,8 +103,6 @@ def main(name=None, config_path=None):
     logging.getLogger("taskcluster").setLevel(logging.WARNING)
     loop = asyncio.get_event_loop()
     kwargs = {}
-    # TODO can we get the signing servers' CA cert on the scriptworkers?
-    # if they're real certs, we can skip this
     if context.config.get('ssl_cert'):
         sslcontext = ssl.create_default_context(cafile=context.config['ssl_cert'])
         kwargs['ssl_context'] = sslcontext

--- a/signingscript/test/test_validate_task.py
+++ b/signingscript/test/test_validate_task.py
@@ -15,12 +15,9 @@ valid_task = json.loads("""
   "expires": "2016-05-08T18:15:59.010Z",
   "scopes": ["signing"],
   "payload": {
-    "signingManifest": "manifest.json"
-  },
-  "extra": {
-    "signing": {
-      "signature": "blah"
-    }
+    "unsignedArtifacts": [
+      "url"
+    ]
   }
 }
 """)


### PR DESCRIPTION
As noted in [bug 1277579](https://bugzilla.mozilla.org/show_bug.cgi?id=1277579), the signingManifest doesn't add very much without another sha or signature.  We prefer links in the task definition rather than the signingManifest; this PR implements that.