### PR TITLE
bump signing token duration from 10m to 20m

### DIFF
--- a/signingscript/task.py
+++ b/signingscript/task.py
@@ -45,7 +45,7 @@ def get_suitable_signing_servers(signing_servers, cert_type, signing_formats):
 
 async def get_token(context, output_file, cert_type, signing_formats):
     token = None
-    data = {"slave_ip": context.config['my_ip'], "duration": 10 * 60}
+    data = {"slave_ip": context.config['my_ip'], "duration": 20 * 60}
     signing_servers = get_suitable_signing_servers(
         context.signing_servers, cert_type,
         signing_formats


### PR DESCRIPTION
re:

2016-11-22 21:40:06,047 - signingscript.script - INFO - signing public/build/fa/target.tar.bz2 from https://tools.taskcluster.net/task-group-inspector/#/CBYx4xkKQ_enRTxc7QvRnQ/fdNYW9-ZSDqZQITXPaQuGA?_k=jdnioj


because we need [moar time!](http://www.myrkothum.com/wp-content/uploads/2013/06/more-time.jpg)

the other l10n  signing tasks took <10m. This one took more. Doubling time to account for slow download times..

@Callek  r?
