### PR TITLE
bug 1346015 - explode dmgs and return dmg-signed tarballs

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -7,5 +7,7 @@
     "ssl_cert": "host.cert",
     "token_duration_seconds": 1200,
     "verbose": true,
+    "dmg": "dmg",
+    "hfsplus": "hfsplus",
     "zipalign": "zipalign"
 }

--- a/signingscript/script.py
+++ b/signingscript/script.py
@@ -59,7 +59,9 @@ async def async_main(context):
             context.config["ssl_cert"]
         )
         sigfiles = detached_sigfiles(path, path_dict['formats'])
-        copy_to_dir(source, context.config['artifact_dir'], target=path)
+        copy_to_dir(
+            os.path.join(work_dir, source), context.config['artifact_dir'], target=source
+        )
         for sigpath in sigfiles:
             copy_to_dir(os.path.join(work_dir, sigpath), context.config['artifact_dir'], target=sigpath)
     log.info("Done!")

--- a/signingscript/script.py
+++ b/signingscript/script.py
@@ -58,6 +58,7 @@ async def async_main(context):
             context, os.path.join(work_dir, path), cert_type, path_dict['formats'],
             context.config["ssl_cert"]
         )
+        source = os.path.relpath(source, work_dir)
         sigfiles = detached_sigfiles(path, path_dict['formats'])
         copy_to_dir(
             os.path.join(work_dir, source), context.config['artifact_dir'], target=source

--- a/signingscript/script.py
+++ b/signingscript/script.py
@@ -54,8 +54,10 @@ async def async_main(context):
     for path, path_dict in filelist_dict.items():
         copy_to_dir(path_dict['full_path'], context.config['work_dir'], target=path)
         log.info("signing %s", path)
-        source = os.path.join(work_dir, path)
-        await sign_file(context, source, cert_type, path_dict['formats'], context.config["ssl_cert"])
+        source = await sign_file(
+            context, os.path.join(work_dir, path), cert_type, path_dict['formats'],
+            context.config["ssl_cert"]
+        )
         sigfiles = detached_sigfiles(path, path_dict['formats'])
         copy_to_dir(source, context.config['artifact_dir'], target=path)
         for sigpath in sigfiles:
@@ -86,6 +88,8 @@ def get_default_config(base_dir=None):
         'schema_file': os.path.join(os.path.dirname(__file__), 'data', 'signing_task_schema.json'),
         'verbose': True,
         'zipalign': 'zipalign',
+        'dmg': 'dmg',
+        'hfsplus': 'hfsplus',
     }
     return default_config
 

--- a/signingscript/task.py
+++ b/signingscript/task.py
@@ -173,7 +173,7 @@ async def sign_file(context, from_, cert_type, signing_formats, cert, to=None):
 async def _execute_pre_signing_steps(context, from_):
     file_base, file_extension = os.path.splitext(from_)
     if file_extension == '.dmg':
-        await _explode_dmg(context, from_)
+        await _convert_dmg_to_tar_gz(context, from_)
         from_ = "{}.tar.gz".format(file_base)
 
     return from_
@@ -215,12 +215,13 @@ async def _zip_align_apk(context, abs_to):
     log.info('"{}" has been zip aligned'.format(abs_to))
 
 
-# _explode_dmg {{{1
-async def _explode_dmg(context, from_):
+# _convert_dmg_to_tar_gz {{{1
+async def _convert_dmg_to_tar_gz(context, from_):
     """Explode a dmg and tar up its contents. Return the relative tarball path."""
     work_dir = context.config['work_dir']
     abs_from = os.path.join(work_dir, from_)
-    to = re.sub(r'''\.dmg$''', '.tar.gz', from_, flags=re.I)
+    # replace .dmg suffix with .tar.gz (case insensitive)
+    to = re.sub('\.dmg$', '.tar.gz', from_, flags=re.I)
     abs_to = os.path.join(work_dir, to)
     dmg_executable_location = context.config['dmg']
     hfsplus_executable_location = context.config['hfsplus']

--- a/signingscript/test/test_script.py
+++ b/signingscript/test/test_script.py
@@ -46,6 +46,9 @@ async def test_async_main(tmpdir, mocker, formats):
     def fake_filelist_dict(*args, **kwargs):
         return {'path1': {'full_path': 'full_path1', 'formats': formats}}
 
+    async def fake_sign(_, val, *args):
+        return val
+
     mocker.patch.object(scriptworker.client, 'get_task', new=noop_sync)
     mocker.patch.object(script, 'validate_task_schema', new=noop_sync)
     mocker.patch.object(script, 'load_signing_server_config', new=noop_sync)
@@ -54,7 +57,7 @@ async def test_async_main(tmpdir, mocker, formats):
     mocker.patch.object(script, 'get_token', new=noop_async)
     mocker.patch.object(script, 'build_filelist_dict', new=fake_filelist_dict)
     mocker.patch.object(script, 'copy_to_dir', new=noop_sync)
-    mocker.patch.object(script, 'sign_file', new=noop_async)
+    mocker.patch.object(script, 'sign_file', new=fake_sign)
     context = mock.MagicMock()
     context.config = {'work_dir': tmpdir, 'ssl_cert': None, 'artifact_dir': tmpdir}
     await script.async_main(context)

--- a/signingscript/test/test_task.py
+++ b/signingscript/test/test_task.py
@@ -179,7 +179,7 @@ async def test_sign_file(context, mocker, format, signtool, event_loop):
     'bar.zip', 'bar.zip',
 )))
 async def test_execute_pre_signing_steps(context, mocker, filename, expected):
-    mocker.patch.object(stask, '_explode_dmg', new=noop_async)
+    mocker.patch.object(stask, '_convert_dmg_to_tar_gz', new=noop_async)
     assert await stask._execute_pre_signing_steps(context, filename) == expected
 
 
@@ -231,9 +231,9 @@ async def test_zip_align_apk(context, monkeypatch, is_verbose):
     await stask._zip_align_apk(context, abs_to)
 
 
-# _explode_dmg {{{1
+# _convert_dmg_to_tar_gz {{{1
 @pytest.mark.asyncio
-async def test_explode_dmg(context, monkeypatch):
+async def test_convert_dmg_to_tar_gz(context, monkeypatch):
     dmg_path = 'path/to/foo.dmg'
     abs_dmg_path = os.path.join(context.config['work_dir'], dmg_path)
     tarball_path = 'path/to/foo.tar.gz'
@@ -253,7 +253,7 @@ async def test_explode_dmg(context, monkeypatch):
     monkeypatch.setattr('signingscript.utils._execute_subprocess', execute_subprocess_mock)
     monkeypatch.setattr('tempfile.TemporaryDirectory', fake_tmpdir)
 
-    await stask._explode_dmg(context, dmg_path)
+    await stask._convert_dmg_to_tar_gz(context, dmg_path)
 
 
 # detached_sigfiles {{{1

--- a/signingscript/test/test_utils.py
+++ b/signingscript/test/test_utils.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from scriptworker.context import Context
-from signingscript.exceptions import SigningServerError
+from signingscript.exceptions import FailedSubprocess, SigningServerError
 from signingscript.test import read_file, tmpdir
 import signingscript.utils as utils
 
@@ -135,3 +135,15 @@ def test_copy_to_dir(tmpdir, source, target, expected, exc):
 
 def test_copy_to_dir_no_copy():
     assert utils.copy_to_dir(SERVER_CONFIG_PATH, os.path.dirname(SERVER_CONFIG_PATH)) is None
+
+
+# _execute_subprocess {{{1
+@pytest.mark.asyncio
+@pytest.mark.parametrize('exit_code', (1, 0))
+async def test_execute_subprocess(exit_code):
+    command = ['bash', '-c', 'exit  {}'.format(exit_code)]
+    if exit_code != 0:
+        with pytest.raises(FailedSubprocess):
+            await utils._execute_subprocess(command)
+    else:
+        await utils._execute_subprocess(command)

--- a/signingscript/test/test_utils.py
+++ b/signingscript/test/test_utils.py
@@ -146,4 +146,4 @@ async def test_execute_subprocess(exit_code):
         with pytest.raises(FailedSubprocess):
             await utils._execute_subprocess(command)
     else:
-        await utils._execute_subprocess(command)
+        await utils._execute_subprocess(command, cwd="/tmp")

--- a/signingscript/utils.py
+++ b/signingscript/utils.py
@@ -137,6 +137,8 @@ def copy_to_dir(source, parent_dir, target=None):
             log.info("Copying %s to %s" % (source, target_path))
             copyfile(source, target_path)
             return target_path
+        else:
+            log.info("Not copying %s to itself" % (source))
     except (IOError, OSError):
         traceback.print_exc()
         raise SigningServerError("Can't copy {} to {}!".format(source, target_path))

--- a/signingscript/utils.py
+++ b/signingscript/utils.py
@@ -142,9 +142,11 @@ def copy_to_dir(source, parent_dir, target=None):
         raise SigningServerError("Can't copy {} to {}!".format(source, target_path))
 
 
-async def _execute_subprocess(command):
+async def _execute_subprocess(command, **kwargs):
     log.info('Running "{}"'.format(' '.join(command)))
-    subprocess = await asyncio.create_subprocess_exec(*command, stdout=PIPE, stderr=STDOUT)
+    subprocess = await asyncio.create_subprocess_exec(
+        *command, stdout=PIPE, stderr=STDOUT, **kwargs
+    )
     log.info("COMMAND OUTPUT: ")
     await log_output(subprocess.stdout)
     exitcode = await subprocess.wait()

--- a/signingscript/utils.py
+++ b/signingscript/utils.py
@@ -143,7 +143,10 @@ def copy_to_dir(source, parent_dir, target=None):
 
 
 async def _execute_subprocess(command, **kwargs):
-    log.info('Running "{}"'.format(' '.join(command)))
+    message = 'Running "{}"'.format(' '.join(command))
+    if 'cwd' in kwargs:
+        message += " in {}".format(kwargs['cwd'])
+    log.info(message)
     subprocess = await asyncio.create_subprocess_exec(
         *command, stdout=PIPE, stderr=STDOUT, **kwargs
     )

--- a/signingscript/utils.py
+++ b/signingscript/utils.py
@@ -1,4 +1,6 @@
 """Signingscript general utility functions."""
+import asyncio
+from asyncio.subprocess import PIPE, STDOUT
 import functools
 import hashlib
 import json
@@ -8,7 +10,7 @@ from shutil import copyfile
 import traceback
 from collections import namedtuple
 
-from signingscript.exceptions import SigningServerError
+from signingscript.exceptions import FailedSubprocess, SigningServerError
 
 log = logging.getLogger(__name__)
 # Mapping between signing client formats and file extensions
@@ -138,3 +140,15 @@ def copy_to_dir(source, parent_dir, target=None):
     except (IOError, OSError):
         traceback.print_exc()
         raise SigningServerError("Can't copy {} to {}!".format(source, target_path))
+
+
+async def _execute_subprocess(command):
+    log.info('Running "{}"'.format(' '.join(command)))
+    subprocess = await asyncio.create_subprocess_exec(*command, stdout=PIPE, stderr=STDOUT)
+    log.info("COMMAND OUTPUT: ")
+    await log_output(subprocess.stdout)
+    exitcode = await subprocess.wait()
+    log.info("exitcode {}".format(exitcode))
+
+    if exitcode != 0:
+        raise FailedSubprocess('Command `{}` failed'.format(' '.join(command)))


### PR DESCRIPTION
- adds an `_explode_dmg` call in a new `_execute_pre_signing_steps`
- `sign_file` now returns the source path; this allows us to rewrite the `path/to/dmg` with a `path/to/tarball` for `async_main` to copy to the `artifact_dir`
- moves `_execute_subprocess` to utils