### PR TITLE
Add a tag for extra datadog filtering

### DIFF
--- a/signingscript/task.py
+++ b/signingscript/task.py
@@ -140,7 +140,8 @@ async def sign(context, path, signing_formats):
         log.info("sign(): Signing {} with {}...".format(output, fmt))
         metric_tags = [
             'format:{}'.format(fmt),
-            'host:{}'.format(platform.node())
+            'host:{}'.format(platform.node()),
+            'app:signingscript'
         ]
         with statsd.timed('signingfunc.time', tags=metric_tags):
             output = await signing_func(context, output, fmt)


### PR DESCRIPTION
This tag should allow us to add filtering in some of datadog's graphs, showing only the signingscript hosts