### PR TITLE
require py37 to be green; unpin taskcluster deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
+      dist: xenial
       env: TOXENV=py37
-  allow_failures:
-    - python: 3.7-dev
+      sudo: true
 
 install:
     - travis_retry pip install tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ datadog==0.17.0
 python-jose
 scriptworker
 signtool>=3.1.6
-taskcluster<4.0.0
+taskcluster

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         "python-jose",
         "scriptworker",
         "signtool",
-        "taskcluster<4.0.0",
+        "taskcluster",
     ],
 )


### PR DESCRIPTION
Now that scriptworker 15 is released, we can use taskcluster 4.