### PR TITLE
strip out META-INF/* from APKs before signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The config json looks like this (comments are not valid json, but I'm inserting 
       // the path to zipalign. This executable is usually present in $ANDROID_SDK_LOCATION/build-tools/$ANDROID_VERSION/zipalign
       "zipalign": "/absolute/path/to/zipalign",
 
+      // the path to zip. This executable is usually present in /usr/bin/zip
+      "zip": "/absolute/path/to/zip",
+
       // The host and port to use when sending metrics to datadog statsd
       // Datadog's default is 8125, ours is 8135 due to a conflict with collectd
       "datadog_port": 8135,

--- a/config_example.json
+++ b/config_example.json
@@ -11,6 +11,7 @@
     "dmg": "dmg",
     "hfsplus": "hfsplus",
     "zipalign": "zipalign",
+    "zip": "zip",
     "datadog_port": 8135,
     "datadog_host": "localhost"
 }

--- a/signingscript/test/integration/test_autograph.py
+++ b/signingscript/test/integration/test_autograph.py
@@ -64,7 +64,8 @@ DEFAULT_CONFIG = {
     "verbose": True,
     "dmg": "dmg",
     "hfsplus": "hfsplus",
-    "zipalign": "zipalign"
+    "zipalign": "zipalign",
+    "zip": "zip"
 }
 
 


### PR DESCRIPTION
fixes: #82
refs: https://github.com/mozilla-services/autograph/issues/159

We could also use https://docs.python.org/3/library/zipfile.html, but the zip binary should be faster and async.

r? @escapewindow 