### PR TITLE
switch to oracle java 8 to fix autograph integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,29 @@ matrix:
   fast_finish: true
   include:
     - python: 3.6
+      dist: xenial
       env:
         - TOXENV=py36
         - AUTOGRAPH_INTEGRATION=1
+        - JAVA_HOME=/usr/lib/jvm/java-8-oracle
+      sudo: true
     - python: 3.7
       dist: xenial
       env:
         - TOXENV=py37
         - AUTOGRAPH_INTEGRATION=1
+        - JAVA_HOME=/usr/lib/jvm/java-8-oracle
       sudo: true
 
+before_install:
+    # Install oracle java 8, because jarsigner in openjdk 11.0.1+13 breaks
+    # integration tests.
+    # https://github.com/mozilla-releng/signingscript/issues/80
+    - sudo add-apt-repository -y ppa:webupd8team/java
+    - sudo apt-get update
+    - echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+    - echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+    - sudo apt-get install oracle-java8-installer
 install:
     - travis_retry pip install tox
 script:

--- a/signingscript/sign.py
+++ b/signingscript/sign.py
@@ -541,7 +541,7 @@ async def _convert_dmg_to_tar_gz(context, from_):
     work_dir = context.config['work_dir']
     abs_from = os.path.join(work_dir, from_)
     # replace .dmg suffix with .tar.gz (case insensitive)
-    to = re.sub('\.dmg$', '.tar.gz', from_, flags=re.I)
+    to = re.sub(r'\.dmg$', '.tar.gz', from_, flags=re.I)
     abs_to = os.path.join(work_dir, to)
     dmg_executable_location = context.config['dmg']
     hfsplus_executable_location = context.config['hfsplus']

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv =
     TRAVIS_JOB_ID
     TRAVIS_BRANCH
     AUTOGRAPH_INTEGRATION
+    JAVA_HOME
 
 deps =
     coverage>=4.2b1


### PR DESCRIPTION
By switching py36 to xenial, we standardize our testing environment.
By installing oracle java 8, we fix our autograph integration tests on xenial.

Fixes #80.

@JohanLorenzo , @g-k , thoughts?