### PR TITLE
Removes "schema_file" from config file

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -2,7 +2,6 @@
     "signing_server_config": "server_config.json",
     "work_dir": "/tmp/work_dir",
     "artifact_dir": "/tmp/artifact_dir",
-    "schema_file": "signingscript/data/signing_task_schema.json",
     "signtool": "signtool",
     "ssl_cert": "host.cert",
     "taskcluster_scope_prefixes": ["project:releng:signing:"],


### PR DESCRIPTION
`signingscript` already has a great `schema_file` default based off of `__file__`